### PR TITLE
Defect r17 2 new business name updating for pervious periods

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/response/party/representation/PartyDTO.java
+++ b/src/main/java/uk/gov/ons/ctp/response/party/representation/PartyDTO.java
@@ -15,6 +15,7 @@ public class PartyDTO {
   private String sampleUnitType;
   private String sampleSummaryId;
   private String sampleUnitRef;
+  private String collectionExerciseId;
   private String name;
   private Attributes attributes;
   private List<Association> associations;

--- a/src/main/java/uk/gov/ons/ctp/response/party/representation/PartyDTO.java
+++ b/src/main/java/uk/gov/ons/ctp/response/party/representation/PartyDTO.java
@@ -15,7 +15,6 @@ public class PartyDTO {
   private String sampleUnitType;
   private String sampleSummaryId;
   private String sampleUnitRef;
-  private String collectionExerciseId;
   private String name;
   private Attributes attributes;
   private List<Association> associations;

--- a/src/main/resources/partysvc/xsd/party-service.xsd
+++ b/src/main/resources/partysvc/xsd/party-service.xsd
@@ -21,6 +21,7 @@
           </xs:restriction>
         </xs:simpleType>
       </xs:element>
+      <xs:element name="collectionExerciseId" type="xs:string" minOccurs="1" maxOccurs="1"/>
       <xs:element name="attributes" type="PartyCreationRequestAttributesDTO" minOccurs="1" maxOccurs="1" />
     </xs:sequence>
   </xs:complexType>

--- a/src/main/resources/partysvc/xsd/party-service.xsd
+++ b/src/main/resources/partysvc/xsd/party-service.xsd
@@ -21,7 +21,7 @@
           </xs:restriction>
         </xs:simpleType>
       </xs:element>
-      <xs:element name="collectionExerciseId" type="xs:string" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="collectionExerciseId" type="xs:string" minOccurs="0" maxOccurs="1"/>
       <xs:element name="attributes" type="PartyCreationRequestAttributesDTO" minOccurs="1" maxOccurs="1" />
     </xs:sequence>
   </xs:complexType>


### PR DESCRIPTION
Add `collectionExerciseId` to `PartyCreationRequestDTO`

Works with other PR's
https://github.com/ONSdigital/rm-collection-exercise-service/pull/43
https://github.com/ONSdigital/ras-party/pull/119
https://github.com/ONSdigital/rm-sample-service/pull/25
https://github.com/ONSdigital/ras-backstage/pull/87

[Trello](https://trello.com/c/nakcH70j/161-defect-r172-if-the-business-name-is-updated-in-a-sample-for-the-next-period-it-is-historically-updating-the-business-name-for-pr)